### PR TITLE
Add Shared Library to subset-band-service

### DIFF
--- a/.github/workflows/build-all-images.yml
+++ b/.github/workflows/build-all-images.yml
@@ -38,6 +38,11 @@ jobs:
             image: "regridder"
             notebook: "Regridder_Regression.ipynb"
           -
+            image: "subset-band-name"
+            notebook: "SubsetBandName_Regression.ipynb"
+            shared-utils: "true"
+            lfs: "true"
+          -
             image: "swath-projector"
             notebook: "SwathProjector_Regression.ipynb"
           -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ versioning. Rather than a static releases, this repository contains of a number
 of regression tests that are each semi-independent.  This CHANGELOG file should be used
 to document pull requests to this repository.
 
+## 2024-10-16 ([#95](https://github.com/nasa/harmony-regression-tests/pull/95))
+
+- TODO: Update this with the changes added for the subet-band-name service
+
 ## 2024-10-11 ([#104](https://github.com/nasa/harmony-regression-tests/pull/104))
 
 - Migrates trajectory-subsetter to use `shared_utils`.

--- a/test/Makefile
+++ b/test/Makefile
@@ -24,7 +24,8 @@ n2z-image: Dockerfile n2z/environment.yaml
 
 nsidc-icesat2-image: Dockerfile nsidc-icesat2/environment.yaml
 	docker build -t ghcr.io/nasa/regression-tests-nsidc-icesat2:latest -f ./Dockerfile \
-	--build-arg notebook=NSIDC-ICESAT2_Regression.ipynb --build-arg sub_dir=nsidc-icesat2 --build-arg shared_utils=true .
+	--build-arg notebook=NSIDC-ICESAT2_Regression.ipynb --build-arg sub_dir=nsidc-icesat2 \
+	--build-arg shared_utils=true .
 
 regridder-image: Dockerfile regridder/environment.yaml
 	docker build -t ghcr.io/nasa/regression-tests-regridder:latest -f ./Dockerfile \
@@ -34,9 +35,15 @@ swath-projector-image: Dockerfile swath-projector/environment.yaml
 	docker build -t ghcr.io/nasa/regression-tests-swath-projector:latest -f ./Dockerfile \
 	--build-arg notebook=SwathProjector_Regression.ipynb --build-arg sub_dir=swath-projector .
 
+subset-band-name-image: Dockerfile subset-band-name/environment.yaml
+	docker build -t ghcr.io/nasa/regression-tests-subset-band-name:latest -f ./Dockerfile \
+	--build-arg notebook=SubsetBandName_Regression.ipynb --build-arg sub_dir=subset-band-name \
+	--build-arg shared_utils=true .
+
 trajectory-subsetter-image: Dockerfile trajectory-subsetter/environment.yaml
 	docker build -t ghcr.io/nasa/regression-tests-trajectory-subsetter:latest -f ./Dockerfile \
-	--build-arg notebook=TrajectorySubsetter_Regression.ipynb --build-arg sub_dir=trajectory-subsetter --build-arg shared_utils=true .
+	--build-arg notebook=TrajectorySubsetter_Regression.ipynb --build-arg sub_dir=trajectory-subsetter \
+	--build-arg shared_utils=true .
 
 variable-subsetter-image: Dockerfile variable-subsetter/environment.yaml
 	docker build -t ghcr.io/nasa/regression-tests-variable-subsetter:latest -f ./Dockerfile \
@@ -45,10 +52,6 @@ variable-subsetter-image: Dockerfile variable-subsetter/environment.yaml
 geoloco-image: Dockerfile geoloco/environment.yaml
 	docker build -t ghcr.io/nasa/regression-tests-geoloco:latest -f ./Dockerfile \
 	--build-arg notebook=Geoloco_Regression.ipynb --build-arg sub_dir=geoloco .
-
-subset-band-name-image: Dockerfile subset-band-name/environment.yaml
-	docker build -t ghcr.io/nasa/regression-tests-subset-band-name:latest -f ./Dockerfile \
-    --build-arg notebook=SubsetBandName_Regression.ipynb --build-arg sub_dir=subset-band-name .
 
 net2cog-image: Dockerfile net2cog/environment.yaml
 	docker build -t ghcr.io/nasa/regression-tests-net2cog:latest -f ./Dockerfile \
@@ -62,9 +65,9 @@ images: harmony-image \
 	n2z-image \
 	nsidc-icesat2-image \
 	regridder-image \
+	subset-band-name-image \
 	swath-projector-image \
 	trajectory-subsetter-image \
 	variable-subsetter-image \
 	geoloco-image \
-	net2cog-image \
-	subset-band-name-image
+	net2cog-image

--- a/test/subset-band-name/SubsetBandName_Regression.ipynb
+++ b/test/subset-band-name/SubsetBandName_Regression.ipynb
@@ -27,13 +27,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "## Import shared utility routines:\n",
+    "import sys\n",
+    "\n",
+    "sys.path.append('../shared_utils')\n",
+    "from utilities import (\n",
+    "    print_error,\n",
+    "    print_success,\n",
+    "    submit_and_download,\n",
+    ")\n",
+    "\n",
     "from harmony import Client, Collection, Environment, Request\n",
     "\n",
     "from utilities import (\n",
-    "    submit_and_download,\n",
     "    remove_results_files,\n",
-    "    print_error,\n",
-    "    print_success,\n",
     "    compare_data,\n",
     ")"
    ]

--- a/test/subset-band-name/environment.yaml
+++ b/test/subset-band-name/environment.yaml
@@ -3,14 +3,12 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.11.0
-  - notebook=7.0.6
-  - papermill=2.3.4
-  - python-dateutil=2.8.2
+  - python=3.11.10
+  - notebook=7.2.2
+  - numpy=1.26.4
+  - papermill=2.6.0
   - hdf4=4.2.15
-  - gcc=13.2.0
-  - zlib=1.2.13
+  - pyhdf=0.11.3
   - pip:
-    - harmony-py==0.4.10
-    - pyhdf==0.11.3
-    - numpy==1.26.2
+    - harmony-py==0.4.15
+    - xarray==2024.9.0

--- a/test/subset-band-name/utilities.py
+++ b/test/subset-band-name/utilities.py
@@ -1,55 +1,10 @@
 """"
-Common utility functions used by the subset-band-name regression tests.
+Utility functions used by the subset-band-name regression tests.
 """
 
 import os
 from pyhdf.SD import SD, SDC
 import numpy
-
-from harmony import Client, Request
-from harmony.harmony import ProcessingFailedException
-
-
-def submit_and_download(
-    harmony_client: Client, request: Request, file_indicator: str
-) -> str:
-    """Submit a Harmony request via a `harmony-py` client. Wait for the
-    Harmony job to finish, then download the results to the specified file
-    path.
-
-    """
-    downloaded_filenames = []
-    output_filename = None
-
-    try:
-        job_id = harmony_client.submit(request)
-
-        print(f"Job ID: {job_id}")
-
-        for filename in [
-            file_future.result()
-            for file_future in harmony_client.download_all(job_id, overwrite=True)
-        ]:
-
-            print(f'Downloaded: {filename}')
-            downloaded_filenames.extend([filename])
-
-            # make a copy to /workdir/output (debugging)
-            # output_filename = f'/workdir/output/{filename.split("/")[-1]}'
-            # os.system(f'cp {filename} {output_filename}')
-
-        for filename in downloaded_filenames:
-            if file_indicator in filename:
-                output_filename = filename
-                print(f'Saved output to: {output_filename}')
-            else:
-                print(f'Could not save output to: {filename}')
-
-    except ProcessingFailedException as exception:
-        print_error('Harmony request failed to complete successfully.')
-        raise exception
-
-    return output_filename
 
 
 def get_dim_sizes(file: str) -> list[int]:
@@ -96,16 +51,6 @@ def remove_results_files() -> None:
     for directory_file in directory_files:
         if directory_file.endswith('.hdf'):
             os.remove(directory_file)
-
-
-def print_error(error_string: str) -> str:
-    """Print an error, with formatting for red text."""
-    print(f'\033[91m{error_string}\033[0m')
-
-
-def print_success(success_string: str) -> str:
-    """Print a success message, with formatting for green text."""
-    print(f'\033[92mSuccess: {success_string}\033[0m')
 
 
 def compare_data(reference_file: str, test_file: str) -> bool:


### PR DESCRIPTION
## Description

This is a PR that modifies https://github.com/nasa/harmony-regression-tests/pull/95 to use the shared_util functionality of the harmony-regression-tests.

It does a few things. 

- Adds subset-band-name to the list of images that are built by github actions.
- Adds lfs and shared-utils to the github actions build
- Adds the shared_utils build_arg to the Makefile for subset-band-name-image target (and alphabetizes the entries)
- updates the notebook to import print_error, print_success, and submit_and_download from the shared_utils directory
- Updates the environment.yaml 
   - with updates to notebook papermill and numpy. 
   - Also removes zlib and gcc because they are not necessary after moving pyhdf into a conda dependency instead of a pip dependency. (I'm not 100% sure that removing this is ok, because of the outstanding problem with the comparison function, but I'm pretty sure this is fine.)


## Jira Issue ID

LDDS-265


## Local Test Steps

You should be able to build the regression-test-image locally with 
```
make subset-band-name-image
```
and run the tests without any import errors (the test results are still not trusted
```
❯ ./run_notebooks.sh subset-band-name
```

also should be able to create a local conda environment from the `test/subset-band-name/environment.yaml` file and run the notebook in your browser. 


## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] CHANGELOG updated with the changes for this PR
